### PR TITLE
Support for package auto-discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ To get started you must first install the package from composer.
 composer require laracademy/interactive-make
 ```
 
+### Laravel >= 5.5
+
+That's it! The package is auto-discovered on 5.5 and up!
+
+### Laravel <= 5.4
+
 Add the package service provider to your `config/app.php`
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,12 @@
         "psr-4": {
           "Laracademy\\Commands\\": "src/"
         }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Laracademy\\Commands\\MakeServiceProvider"
+            ]
+        }
     }
 }


### PR DESCRIPTION
Well, that was easy!

This will make the package auto-load in Laravel 5.5 ans up, and it doesn't conflict with anything for earlier versions that will need to include the service provider.